### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/etlt/condition/SimpleConditionFactory.py
+++ b/etlt/condition/SimpleConditionFactory.py
@@ -53,10 +53,10 @@ class SimpleConditionFactory:
         :param callable constructor: The SimpleCondition constructor.
         """
         if not re.match(r'/^([a-z]+)$/', scheme):
-            raise ValueError('%s is not a valid scheme' % scheme)
+            raise ValueError('{0!s} is not a valid scheme'.format(scheme))
 
         if scheme in SimpleConditionFactory._constructors:
-            raise ValueError('Scheme %s is registered already' % scheme)
+            raise ValueError('Scheme {0!s} is registered already'.format(scheme))
 
         SimpleConditionFactory._constructors[scheme] = constructor
 
@@ -73,7 +73,7 @@ class SimpleConditionFactory:
         scheme, actual = SimpleConditionFactory._split_scheme(expression)
 
         if scheme not in SimpleConditionFactory._constructors:
-            raise ValueError('Scheme %s is not registered' % scheme)
+            raise ValueError('Scheme {0!s} is not registered'.format(scheme))
 
         return SimpleConditionFactory._constructors[scheme](field, actual)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
