### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/etlt/helper/Type2Helper.py
+++ b/etlt/helper/Type2Helper.py
@@ -93,7 +93,7 @@ class Type2Helper:
         if isinstance(date, datetime.date):
             return date.toordinal()
 
-        raise ValueError('Unexpected type %s' % date.__class__)
+        raise ValueError('Unexpected type {0!s}'.format(date.__class__))
 
     # ------------------------------------------------------------------------------------------------------------------
     @staticmethod
@@ -111,7 +111,7 @@ class Type2Helper:
         if isinstance(date, datetime.date):
             return 'date'
 
-        raise ValueError('Unexpected type %s' % date.__class__)
+        raise ValueError('Unexpected type {0!s}'.format(date.__class__))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _sort_data(self):
@@ -356,7 +356,7 @@ class Type2Helper:
                 row[self._key_start_date] = datetime.date.fromordinal(row[self._key_start_date])
                 row[self._key_end_date] = datetime.date.fromordinal(row[self._key_end_date])
             else:
-                raise ValueError('Unexpected date type %s' % self._date_type)
+                raise ValueError('Unexpected date type {0!s}'.format(self._date_type))
 
     # ------------------------------------------------------------------------------------------------------------------
     def merge(self, keys):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
