### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/etlt/writer/SqlLoaderWriter.py
+++ b/etlt/writer/SqlLoaderWriter.py
@@ -88,7 +88,7 @@ class SqlLoaderWriter(Writer):
     def _write_field(self, value):
         class_name = str(value.__class__)
         if class_name not in self.handlers:
-            raise ValueError('No handler has been registered for class: %s' % class_name)
+            raise ValueError('No handler has been registered for class: {0!s}'.format(class_name))
         handler = self.handlers[class_name]
         handler(value, self._file)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
