### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/etlt/helper/Type2CondenseHelper.py
+++ b/etlt/helper/Type2CondenseHelper.py
@@ -65,7 +65,7 @@ class Type2CondenseHelper(Type2Helper):
         if relation == Allen.X_EQUAL_Y:
             return None  # [(start1, end1)]
 
-        raise ValueError('Unexpected relation %d' % relation)
+        raise ValueError('Unexpected relation {0:d}'.format(relation))
 
     # ------------------------------------------------------------------------------------------------------------------
     @staticmethod


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
