### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/etlt/helper/Type2JoinHelper.py
+++ b/etlt/helper/Type2JoinHelper.py
@@ -200,7 +200,7 @@ class Type2JoinHelper(Type2Helper):
                     # Hence the following relation should not occur: X_DURING_Y,  X_FINISHES_Y, X_BEFORE_Y_INVERSE,
                     # X_MEETS_Y_INVERSE, X_OVERLAPS_WITH_Y_INVERSE, and X_STARTS_Y_INVERSE. Hence, we covered all 13
                     # relations in Allen's interval algebra.
-                    raise ValueError('Data is not sorted properly. Relation: %d' % relation)
+                    raise ValueError('Data is not sorted properly. Relation: {0:d}'.format(relation))
             else:
                 prev_row = row
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-etlt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
